### PR TITLE
fix : 중고도서 게시글 등록 isbn 하이픈 제거

### DIFF
--- a/src/components/SaleInsert/SaleInsertIsbn.tsx
+++ b/src/components/SaleInsert/SaleInsertIsbn.tsx
@@ -2,17 +2,24 @@ import { Controller, RegisterOptions } from "react-hook-form";
 import { TextField } from "@mui/material";
 import { memo } from "react";
 import ErrorMessage from "elements/ErrorMessage";
-import { hookFormIsbnCheck, makeOption } from "utils/hookFormUtil";
+import {
+  hookFormIsbnCheck,
+  hookFormKoreaChractersCheck,
+  hookFormSpecialChractersCheck,
+  makeOption,
+} from "utils/hookFormUtil";
 import * as Styled from "./style";
 import * as Types from "./types";
 
 const SaleInsertIsbn = ({ control, error }: Types.SaleInsertProps) => {
-  const priceOpions: RegisterOptions = {
+  const priceOpions: RegisterOptions<Types.SaleInsertForm> = {
     required: "필수입니다.",
-    maxLength: makeOption<number>(17, "ISBN은 최대 17자리입니다."),
-    minLength: makeOption<number>(13, "ISBN은 최소 13자리입니다."),
+    maxLength: makeOption<number>(13, "ISBN은 최대 13자리입니다."),
+    minLength: makeOption<number>(10, "ISBN은 최소 10자리입니다."),
     validate: {
-      isbn: value => hookFormIsbnCheck(value, "ISBN 형식이 아닙니다."),
+      koreaLang: value => hookFormKoreaChractersCheck(value, "한글은 입력 불가능합니다."),
+      spacialLang: value => hookFormSpecialChractersCheck(value, "특수문자는 입력 불가능합니다."),
+      isbn: value => hookFormIsbnCheck(value, "ISBN 검증 번호가 잘못 되었습니다."),
     },
   };
 
@@ -32,7 +39,7 @@ const SaleInsertIsbn = ({ control, error }: Types.SaleInsertProps) => {
               {...field}
               fullWidth
               type="text"
-              placeholder="ISBN은 13~17자리입니다. (-포함)"
+              placeholder="ISBN은 10~13자리입니다. (-미포함)"
               color="mainDarkBrown"
               error={error ? true : false}
             />

--- a/src/utils/hookFormUtil.ts
+++ b/src/utils/hookFormUtil.ts
@@ -43,8 +43,8 @@ export const htmlTagPatternCheck = (value: string) => /(<([^>]+)>)/g.test(value)
 /**
  * @param value isbn 10자리, 13자리
  * example Matches
- * 89-5674-189-1
- * 979-11-6224-448-7
+ * 8956741891
+ * 9791162244487
  * @returns boolean
  */
 export const isbnPatternCheck = (value: string) =>
@@ -106,16 +106,16 @@ export const hookFormHtmlCheck: HookFormCheckType = (value, errorMessage) => {
 /**
  * @param value isbn 10자리, 13자리
  * example Matches
- * 89-5674-189-1
- * 979-11-6224-448-7
+ * 8956741891
+ * 9791162244487
  * @returns boolean | string
  */
 export const hookFormIsbnCheck: HookFormCheckType = (value, errorMessage) => {
   // ISBN형식이 맞는지 체크 후
   // 유효한 ISBN인지 확인을 한다.
-  if (isbnPatternCheck(value) === false) {
-    return errorMessage;
-  }
+  // if (isbnPatternCheck(value) === false) {
+  //   return errorMessage;
+  // }
 
   const chars = value.replace(/[^0-9X]/g, "").split("");
   const last = chars.pop();
@@ -145,7 +145,7 @@ export const hookFormIsbnCheck: HookFormCheckType = (value, errorMessage) => {
   }
 
   if (String(checksum) !== last) {
-    return "ISBN 검증 번호가 잘못 되었습니다.";
+    return errorMessage;
   }
 
   return true;


### PR DESCRIPTION
1. 중고도서 게시글 등록 isbn 하이픈 제거
    -  10~13자리 isbn 등록 시 하이픈은 제거해서 입력하도록 변경
    -  서버에 보낼때 하이픈 제거된 상태로 데이터 전송 
![image](https://user-images.githubusercontent.com/26589722/153120209-3ad242d9-dc1c-46d5-811b-27079a45e661.png)
