### PR TITLE
fix : 마이페이지 유저리뷰 버그 수정 및 구매상세 버튼 스타일 수정

### DIFF
--- a/src/components/BuyInfo/BuyInfo.tsx
+++ b/src/components/BuyInfo/BuyInfo.tsx
@@ -3,7 +3,7 @@ import { useHistory, useParams } from "react-router";
 import { fetchBuyInfoAsync, userBuyInfoSelector, userReduceSelector } from "modules/Slices/user/userSlice";
 import { useAppDispatch, useTypedSelector } from "modules/store";
 import { hyphenFormat, dateArrayFormat, make1000UnitsCommaFormet } from "utils/formatUtil";
-import { Button } from "@mui/material";
+import { Button, Stack } from "@mui/material";
 import { Link } from "react-router-dom";
 import Loading from "elements/Loading";
 import * as Types from "./types";
@@ -23,9 +23,16 @@ const BuyInfo = () => {
 
   const goback = useMemo(
     () => (
-      <Button variant="contained" color="mainDarkBrown" fullWidth sx={{ mt: 2, height: 50 }} onClick={handleGoBack}>
-        뒤로가기
-      </Button>
+      <Stack justifyContent="center" flexDirection="row">
+        <Button
+          variant="outlined"
+          color="info"
+          sx={{ mt: 2, mb: 1, height: 50, fontWeight: "bold", maxWidth: 120, fontSize: 15 }}
+          onClick={handleGoBack}
+        >
+          뒤로가기
+        </Button>
+      </Stack>
     ),
     [handleGoBack],
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -49,13 +49,7 @@ const Header = () => {
     dispatch(logout());
   }, [dispatch]);
 
-  const infos = useMemo<
-    {
-      endPoint: string;
-      text: string;
-      onClick?: () => void;
-    }[]
-  >(
+  const infos = useMemo<Types.Infos[]>(
     () =>
       user
         ? [

--- a/src/components/Header/types.ts
+++ b/src/components/Header/types.ts
@@ -1,3 +1,9 @@
 export interface SearchForm {
   title: string;
 }
+
+export type Infos = {
+  endPoint: string;
+  text: string;
+  onClick?: () => void;
+};

--- a/src/components/MyReview/MyReview.tsx
+++ b/src/components/MyReview/MyReview.tsx
@@ -1,7 +1,13 @@
 import { useAppDispatch, useTypedSelector } from "modules/store";
 import queryString from "query-string";
 import { useEffect } from "react";
-import { userReviewsSelector, fetchReviewAsync, setReviewPage, userSelector } from "modules/Slices/user/userSlice";
+import {
+  userReviewsSelector,
+  fetchReviewAsync,
+  setReviewPage,
+  userSelector,
+  setReivewsReset,
+} from "modules/Slices/user/userSlice";
 import { Stack, Typography } from "@mui/material";
 import Pagination from "@mui/material/Pagination";
 import Loading from "elements/Loading";
@@ -35,9 +41,13 @@ const MyReview = () => {
   };
 
   useEffect(() => {
-    if (user === null || page !== 0 || contents !== null) return;
-    const query = makeQuery(page, size);
-    dispatch(fetchReviewAsync({ userId: user.id, query }));
+    if (user !== null && page === 0 && contents === null) {
+      const query = makeQuery(page, size);
+      dispatch(fetchReviewAsync({ userId: user.id, query }));
+    }
+    return () => {
+      if (contents !== null) dispatch(setReivewsReset());
+    };
   }, [dispatch, user, page, size, contents]);
 
   if (contents) {

--- a/src/components/SearchForm/SearchBookReview.tsx
+++ b/src/components/SearchForm/SearchBookReview.tsx
@@ -48,7 +48,7 @@ const SearchBookReview = () => {
           <Grid item xs={12}>
             <Styled.SearchEmpty>
               <img src={noComments} alt="noComments" />
-              <p>죄송합니다. 알라딘 결과가 없습니다.</p>
+              <p>죄송합니다. 리뷰 결과가 없습니다.</p>
             </Styled.SearchEmpty>
           </Grid>
         )}

--- a/src/modules/Slices/user/types.ts
+++ b/src/modules/Slices/user/types.ts
@@ -91,6 +91,16 @@ export interface ThunkApi {
   state: RootState;
 }
 
+export type Reviews = {
+  page: number;
+  pageCount: number;
+  contents: Content[][] | null;
+  empty: boolean;
+  size: number;
+  status: "loading" | "idle";
+  error: string | null;
+};
+
 export interface UserReduce {
   user: UserInfo | null;
   token: string | null;
@@ -99,13 +109,5 @@ export interface UserReduce {
   error: null | string;
   saleInfos: OrderResult[];
   buyInfos: OrderResult[];
-  reviews: {
-    page: number;
-    pageCount: number;
-    contents: Content[][] | null;
-    empty: boolean;
-    size: number;
-    status: "loading" | "idle";
-    error: string | null;
-  };
+  reviews: Reviews;
 }

--- a/src/modules/Slices/user/userSlice.ts
+++ b/src/modules/Slices/user/userSlice.ts
@@ -146,6 +146,16 @@ export const fetchReviewAsync = createAsyncThunk<Types.Review, { userId: number;
   },
 );
 
+const reviewsInit: Types.Reviews = {
+  contents: null,
+  empty: false,
+  page: 0,
+  pageCount: 0,
+  size: 10,
+  status: "idle",
+  error: null,
+};
+
 const initialState: Types.UserReduce = {
   user: null,
   token: null,
@@ -154,36 +164,26 @@ const initialState: Types.UserReduce = {
   status: "idle",
   buyInfos: [],
   saleInfos: [],
-  reviews: {
-    contents: null,
-    empty: false,
-    page: 0,
-    pageCount: 0,
-    size: 10,
-    status: "idle",
-    error: null,
-  },
+  reviews: reviewsInit,
 };
 
 const userSlice = createSlice({
   name: NAME,
   initialState,
   reducers: {
-    // 액션함수 이름 logout
-    // 함수 내용 리듀서
-    logout: state => {
-      state.user = null;
-      state.token = null;
-      state.isLoggedIn = false;
-      state.error = null;
+    logout: () => {
       removeToken();
       alert("로그아웃 되었습니다.");
+      return initialState;
     },
     setClearError: state => {
       state.error = null;
     },
     setReviewPage: (state, action) => {
       state.reviews.page = action.payload;
+    },
+    setReivewsReset: state => {
+      state.reviews = reviewsInit;
     },
   },
   extraReducers: builder => {
@@ -290,5 +290,5 @@ export const userBuyInfoSelector =
   ({ userReduce }: RootState) =>
     userReduce.buyInfos.find(info => info.orderId === orderId);
 export const userReviewsSelector = ({ userReduce }: RootState) => userReduce.reviews;
-export const { logout, setClearError, setReviewPage } = userSlice.actions;
+export const { logout, setClearError, setReviewPage, setReivewsReset } = userSlice.actions;
 export default userSlice;


### PR DESCRIPTION
### 1. 통합검색 페이지 수정
  - 기존 알라딘 결과 키워드에서 `리뷰 결과` 키워드로 수정
  
<p align="center">
 <img src=https://user-images.githubusercontent.com/26589722/153584885-3051e22c-0acf-403e-a4f3-d2e9d878baa1.png
width=300 height=150
/>
</p>

### 2. 구매상세 페이지 수정
  - 버튼 너비 150px로 수정
<p align="center">
 <img src=https://user-images.githubusercontent.com/26589722/153585247-ff446c45-4f0c-4218-bca9-ed136f409aa8.png
width=300 height=150
/>
</p>

### 3. 마이리뷰페이지 수정
  - 리뷰를 작성후 로그아웃하면 이전 유저가 작성한 리뷰 보이는 버그 수정
  - 컴포넌트가 없어질때 user 스토어에 reviews 초기화 해주도록 변경
<p align="center">
 <img src=https://user-images.githubusercontent.com/26589722/153585486-5d05b296-c66b-4f72-ab99-da1f55392e13.png
width="100%" height=250
/>
</p>


