### PR TITLE
다른 회원 마이페이지(Shop) 추가, 상점정보, 상점후기 유저 이미지 추가, 리뷰 파라미터 방식 userId로 변경

### DIFF
--- a/src/components/BuyList/BuyList.tsx
+++ b/src/components/BuyList/BuyList.tsx
@@ -20,8 +20,9 @@ import { useTypedSelector } from "modules/store";
 import ContentList from "./ContentList";
 import MyPageSkeleton from "./MyPageSkeleton";
 import { ReviewListEmptyParagraph, ReviewListEmptyWrapper } from "../Reviews/ReviewList/style";
-import { BuyListWrapper, FlexBox, HeaderTitle, HeaderWrapper } from "./styles";
+import { BuyListWrapper, FlexBox } from "./styles";
 import { BuyListResponse } from "./types";
+import { UserReviewCell, UserReviewHeader } from "../UserReview/styles";
 
 export interface buyConfirmSubmitParam {
   orderId: string;
@@ -114,11 +115,15 @@ const BuyList = () => {
     };
   });
 
-  const headerList = headers.map((header, idx) => (
-    <div key={idx}>
-      <HeaderTitle>{header}</HeaderTitle>
-    </div>
-  ));
+  const headerList = (
+    <UserReviewHeader>
+      {headers.map((text, idx) => (
+        <UserReviewCell key={idx}>
+          <span>{text}</span>
+        </UserReviewCell>
+      ))}
+    </UserReviewHeader>
+  );
 
   const contentList =
     pages.length !== 0 ? (
@@ -190,7 +195,7 @@ const BuyList = () => {
           </Select>
         </FormControl>
       </Stack>
-      <HeaderWrapper>{headerList}</HeaderWrapper>
+      {headerList}
       <div>{contentList}</div>
       {list.isEmpty || (
         <Stack mt={5} justifyContent="center" direction="row">

--- a/src/components/BuyList/ContentList.tsx
+++ b/src/components/BuyList/ContentList.tsx
@@ -54,65 +54,69 @@ const ContentList = ({ pages, select, titleFilter, open, setOpen }: IContent) =>
       }
       return alert("재로그인 후 다시 시도하세요.");
     }
+    e.preventDefault();
     return false;
   };
 
   return (
     <div>
       {contents.length ? (
-        contents.map((item, idx) => (
-          <ContentWrapper key={idx}>
-            <BuyContent>
-              <Link to={`/usedBook/${item.bookId}`}>
-                {item.image.length !== 0 && (
-                  <ImgContent src={`${process.env.BASE_URL}/image/${item.image}`} alt="usedBookImg" />
-                )}
-              </Link>
-            </BuyContent>
-            <BuyContent>
-              <ContentText>
-                {item.state === "SALE" && "거래취소"}
-                {item.state === "TRADING" && "거래중"}
-                {item.state === "SOLD_OUT" && "거래완료"}
-              </ContentText>
-            </BuyContent>
-            <BuyTitleContent>
-              <ContentText>{item.title}</ContentText>
-            </BuyTitleContent>
-            <BuyContent>
-              <ContentText>{item.price}</ContentText>
-            </BuyContent>
-            <BuyContent>
-              <ContentText>{item.orderDate.split("T", 1)}</ContentText>
-            </BuyContent>
-            <BuyContent>
-              <ButtonArea>
-                {item.state === "TRADING" ? (
-                  <form onSubmit={buyConfirmSubmit}>
-                    <Button variant="outlined" type="submit">
-                      구매확정
-                      <input type="hidden" value={item.orderId} />
-                    </Button>
-                  </form>
-                ) : item.state === "SOLD_OUT" ? (
-                  item.reviewId ? (
-                    <Button disabled>리뷰작성완료</Button>
-                  ) : (
-                    <Button variant="contained" onClick={() => expandModal(item)} type="button">
-                      리뷰작성
-                    </Button>
-                  )
-                ) : null}
-                <Link to={`buy/${item.orderId}`}>
-                  <Button variant="contained" color="inherit">
-                    구매상세
-                  </Button>
+        contents.map((item, idx) => {
+          const { image, orderDate, orderId, price, reviewId, state, title, bookId } = item;
+          return (
+            <ContentWrapper key={idx}>
+              <BuyContent>
+                <Link to={`/usedBook/${bookId}`}>
+                  {image.length !== 0 && (
+                    <ImgContent src={`${process.env.BASE_URL}/image/${image}`} alt="usedBookImg" />
+                  )}
                 </Link>
-              </ButtonArea>
-            </BuyContent>
-            {open ? <Modal open={open} handleClose={handleClose} item={selectedItem} /> : null}
-          </ContentWrapper>
-        ))
+              </BuyContent>
+              <BuyContent>
+                <ContentText>
+                  {state === "SALE" && "거래취소"}
+                  {state === "TRADING" && "거래중"}
+                  {state === "SOLD_OUT" && "거래완료"}
+                </ContentText>
+              </BuyContent>
+              <BuyTitleContent>
+                <ContentText>{title}</ContentText>
+              </BuyTitleContent>
+              <BuyContent>
+                <ContentText>{price}</ContentText>
+              </BuyContent>
+              <BuyContent>
+                <ContentText>{orderDate.split("T", 1)}</ContentText>
+              </BuyContent>
+              <BuyContent>
+                <ButtonArea>
+                  {state === "TRADING" ? (
+                    <form onSubmit={buyConfirmSubmit}>
+                      <Button variant="outlined" type="submit">
+                        구매확정
+                        <input type="hidden" value={orderId} />
+                      </Button>
+                    </form>
+                  ) : state === "SOLD_OUT" ? (
+                    reviewId ? (
+                      <Button disabled>리뷰작성완료</Button>
+                    ) : (
+                      <Button variant="contained" onClick={() => expandModal(item)} type="button">
+                        리뷰작성
+                      </Button>
+                    )
+                  ) : null}
+                  <Link to={`buy/${item.orderId}`}>
+                    <Button variant="contained" color="inherit">
+                      구매상세
+                    </Button>
+                  </Link>
+                </ButtonArea>
+              </BuyContent>
+              {open ? <Modal open={open} handleClose={handleClose} item={selectedItem} /> : null}
+            </ContentWrapper>
+          );
+        })
       ) : (
         <Empty>
           <p>조건에 맞는 내용이 없습니다.</p>

--- a/src/components/BuyList/Modal.tsx
+++ b/src/components/BuyList/Modal.tsx
@@ -12,20 +12,20 @@ import { addUserReview, editUserReview } from "modules/Slices/userReview/userRev
 import {
   RegisterButton,
   TextReviewArea,
-  ButtonArea,
   CancelButton,
   ModalContent,
   BuyContent,
   FlexWrapper,
   ImgContent,
   Text,
+  ModalButtonArea,
 } from "./styles";
 import { HoverRating } from "../Rating/Rating";
 import { addUserReviewSubmitParam } from "./types";
 
 export interface userReviewModalProps {
   open: boolean;
-  item: ModalItemParam | null;
+  item: ModalItemParam;
   handleClose: () => void;
 }
 
@@ -145,13 +145,13 @@ const Modal = (props: userReviewModalProps) => {
             />
           </TextReviewArea>
           <div>
-            <ButtonArea>
-              <CancelButton onClick={handleClose}>취소</CancelButton>
+            <ModalButtonArea>
               <RegisterButton type="submit">
                 {orderDate && "등록"}
                 {reviewDate && "수정"}
               </RegisterButton>
-            </ButtonArea>
+              <CancelButton onClick={handleClose}>취소</CancelButton>
+            </ModalButtonArea>
           </div>
         </DialogContent>
       </form>

--- a/src/components/BuyList/styles.ts
+++ b/src/components/BuyList/styles.ts
@@ -55,7 +55,10 @@ export const ContentText = styled.div`
 export const ButtonArea = styled.div`
   align-content: center;
   margin: 50px auto;
-  // display: flex;
+`;
+
+export const ModalButtonArea = styled(ButtonArea)`
+  display: flex;
 `;
 
 export const ModalContent = styled.div`

--- a/src/components/BuyList/styles.ts
+++ b/src/components/BuyList/styles.ts
@@ -8,15 +8,11 @@ export const ColorContent = styled.div`
   color: #52a4c3;
 `;
 
-export const BuyListWrapper = styled.div`
-  padding-top: 60px;
-`;
-
 export const HeaderTitle = styled.div`
   font-size: 18px;
   padding: 20px;
   text-align: center;
-  width: 180px;
+  flex: 1;
   border-top: 1px solid black;
   border-bottom: 1px solid black;
 `;
@@ -31,7 +27,7 @@ export const BuyContent = styled.div`
   font-size: 18px;
   text-align: center;
   padding: 20px;
-  width: 180px;
+  width: 200px;
   height: 220px;
 `;
 
@@ -123,7 +119,7 @@ export const ContentItem = styled.div`
   font-size: 18px;
   text-align: center;
   padding: 20px;
-  width: 180px;
+  flex: 1;
   height: 170px;
 `;
 
@@ -142,4 +138,10 @@ export const TextReviewArea = styled.div`
   padding: 10px 10px 11px;
   border: 1px solid #cbcbcb;
   background-color: #f4f4f4;
+`;
+
+export const BuyListWrapper = styled.div`
+  margin: 3rem 0;
+  padding: 0 1rem;
+  flex: 1;
 `;

--- a/src/components/MyTop/MyTop.tsx
+++ b/src/components/MyTop/MyTop.tsx
@@ -75,8 +75,9 @@ const MyTop = () => {
   );
 
   useEffect(() => {
-    if (token) {
-      dispatch(getMyPageChart(token));
+    if (user) {
+      const { id } = user;
+      dispatch(getMyPageChart(String(id)));
     }
   }, []);
 

--- a/src/components/MyTop/MyTop.tsx
+++ b/src/components/MyTop/MyTop.tsx
@@ -149,7 +149,16 @@ const MyTop = () => {
         )}
         <Styled.MyChartWrapper>
           <Styled.TitleSpan>선호 장르</Styled.TitleSpan>
-          <MyChart data={myPageChart} />
+          {myPageChart.length !== 0 ? (
+            <MyChart data={myPageChart} />
+          ) : (
+            <Styled.EmptyChart>
+              <div>
+                <p>선호장르 데이터가 없습니다.</p>
+                <p>첫 리뷰를 작성해주세요!</p>
+              </div>
+            </Styled.EmptyChart>
+          )}
         </Styled.MyChartWrapper>
       </Styled.MyTopWrapper>
     </>

--- a/src/components/MyTop/style.ts
+++ b/src/components/MyTop/style.ts
@@ -225,3 +225,21 @@ export const TitleSpan = styled.span`
   font-weight: 600;
   color: #787878;
 `;
+
+export const EmptyChart = styled.div`
+  display: flex;
+  height: 300px;
+  align-items: center;
+  flex-direction: row;
+  justify-content: center;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 14px;
+
+  div {
+    flex-direction: column;
+  }
+
+  p {
+    margin-bottom: 5px;
+  }
+`;

--- a/src/components/Reviews/ReviewList/BestReviewItem.tsx
+++ b/src/components/Reviews/ReviewList/BestReviewItem.tsx
@@ -56,12 +56,11 @@ const BestReviewItem = ({ item }: BestReviewItemParam) => {
         <Rating name="read-only" precision={0.5} value={rating} size="small" readOnly />
         <DateWrapper>
           {date !== 0 ? (
-            <>
+            <span>
               {date} {dayAgo}
-            </>
+            </span>
           ) : (
-            // eslint-disable-next-line react/jsx-no-useless-fragment
-            <>{dayAgo}</>
+            <span>{dayAgo}</span>
           )}
         </DateWrapper>
       </div>

--- a/src/components/Reviews/ReviewList/BestReviewItem.tsx
+++ b/src/components/Reviews/ReviewList/BestReviewItem.tsx
@@ -4,6 +4,7 @@ import useSignIn from "src/hooks/useSignIn";
 import { commentLike } from "src/modules/Slices/comment/commentSlice";
 import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import { compareDateFormat } from "src/utils/formatUtil";
+import { Link } from "react-router-dom";
 import {
   BestCommentNickName,
   BestCommentWrapper,
@@ -15,11 +16,11 @@ import {
 import { BestReviewItemParam } from "./types";
 
 const BestReviewItem = ({ item }: BestReviewItemParam) => {
-  const { content, nickName, rating, reviewLikeCount, reviewId, reviewDate } = item;
+  const { content, nickName, rating, reviewLikeCount, reviewId, reviewDate, userId } = item;
   const { signIn, dispatch } = useSignIn();
   const history = useHistory();
   const { user, isLoggedIn, token } = signIn;
-
+  const shopId = String(userId);
   const likeClick = () => {
     if (!isLoggedIn) {
       if (window.confirm("로그인이 필요합니다. 로그인 페이지로 이동하시겠습니까?")) {
@@ -49,7 +50,9 @@ const BestReviewItem = ({ item }: BestReviewItemParam) => {
   return (
     <BestCommentWrapper>
       <div>
-        <BestCommentNickName>{nickName}</BestCommentNickName>
+        <Link to={`/shop/${shopId}`}>
+          <BestCommentNickName>{nickName}</BestCommentNickName>
+        </Link>
         <Rating name="read-only" precision={0.5} value={rating} size="small" readOnly />
         <DateWrapper>
           {date !== 0 ? (

--- a/src/components/Reviews/ReviewList/ReviewItem.tsx
+++ b/src/components/Reviews/ReviewList/ReviewItem.tsx
@@ -7,6 +7,7 @@ import { useTypedSelector } from "modules/store";
 import { userReduceSelector } from "modules/Slices/user/userSlice";
 import { reviewDateFormat } from "utils/formatUtil";
 import { useHistory } from "react-router";
+import { Link } from "react-router-dom";
 import {
   ContentWrapper,
   ReviewContent,
@@ -29,6 +30,7 @@ export const ReviewItem: React.FC<ReviewItemProps> = ({ content }) => {
   const commentDate = reviewDateFormat(reviewDate);
   const myUserStatus = useTypedSelector(userReduceSelector);
   const { user, isLoggedIn, token } = myUserStatus;
+  const shopId = String(userId);
 
   const deleteClick = () => {
     if (token) {
@@ -69,7 +71,9 @@ export const ReviewItem: React.FC<ReviewItemProps> = ({ content }) => {
       <ReviewContent>
         <ReviewContentTop>
           <Rating name="read-only" precision={0.5} value={rating} size="small" readOnly />
-          <p>{nickName}</p>
+          <Link to={`/shop/${shopId}`}>
+            <p>{nickName}</p>
+          </Link>
           <ContentBottom>
             <ReplyDate>{commentDate}</ReplyDate>
           </ContentBottom>

--- a/src/components/ShopMenu/ShopBookReview.tsx
+++ b/src/components/ShopMenu/ShopBookReview.tsx
@@ -1,0 +1,84 @@
+import { useAppDispatch, useTypedSelector } from "modules/store";
+import queryString from "query-string";
+import { useEffect } from "react";
+import { userReviewsSelector, fetchReviewAsync, setReviewPage, userSelector } from "modules/Slices/user/userSlice";
+import { Stack } from "@mui/material";
+import Pagination from "@mui/material/Pagination";
+import Loading from "elements/Loading";
+import noComments from "assets/image/noComments.png";
+import MyReviewTable from "../MyReview/MyReviewTable";
+import { MyReviewEmpty, MyReviewWrapper } from "../MyReview/style";
+import { Title, TitleSpan } from "../UsedBookLikeList/styles";
+
+const ShopBookReview = () => {
+  const { empty, contents, page, pageCount, size, status } = useTypedSelector(userReviewsSelector);
+  const loading = status === "loading";
+  const shop = useTypedSelector(userSelector);
+  const dispatch = useAppDispatch();
+
+  const makeQuery = (userId: number, page: number, size: number) => {
+    return queryString.stringify({
+      userId,
+      page,
+      size,
+    });
+  };
+
+  const handlePaginationOnChange = (_: any, value: number) => {
+    if (shop) {
+      const currentPage = value - 1;
+      if (contents && contents[currentPage]) {
+        dispatch(setReviewPage(currentPage));
+      } else {
+        const query = makeQuery(shop.id, currentPage, size);
+        dispatch(fetchReviewAsync(query));
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (shop === null || page !== 0 || contents !== null) return;
+    const query = makeQuery(shop.id, page, size);
+    dispatch(fetchReviewAsync(query));
+  }, [dispatch, shop, page, size, contents]);
+
+  if (contents) {
+    return (
+      <MyReviewWrapper>
+        <Loading isLoading={loading} />
+        <Title>
+          <TitleSpan>최근 작성한 도서 리뷰</TitleSpan>
+        </Title>
+        {empty ? (
+          <MyReviewEmpty>
+            <img src={noComments} alt="noComments" />
+            <p>작성한 리뷰가 없습니다.</p>
+          </MyReviewEmpty>
+        ) : (
+          <MyReviewTable contents={contents[page]} />
+        )}
+        {empty || (
+          <Stack justifyContent="center" direction="row">
+            <Pagination
+              count={pageCount}
+              page={page + 1}
+              onChange={handlePaginationOnChange}
+              variant="outlined"
+              size="large"
+              sx={{
+                ".Mui-selected": {
+                  background: theme => theme.colors.mainDarkBrown,
+                  color: theme => theme.colors.white,
+                },
+              }}
+            />
+          </Stack>
+        )}
+      </MyReviewWrapper>
+    );
+  }
+
+  return null;
+};
+
+export default ShopBookReview;

--- a/src/components/ShopMenu/ShopBookReview.tsx
+++ b/src/components/ShopMenu/ShopBookReview.tsx
@@ -1,7 +1,13 @@
 import { useAppDispatch, useTypedSelector } from "modules/store";
 import queryString from "query-string";
 import { useEffect } from "react";
-import { userReviewsSelector, fetchReviewAsync, setReviewPage, userSelector } from "modules/Slices/user/userSlice";
+import {
+  userReviewsSelector,
+  fetchReviewAsync,
+  setReviewPage,
+  setReivewsReset,
+  userReduceSelector,
+} from "modules/Slices/user/userSlice";
 import { Stack } from "@mui/material";
 import Pagination from "@mui/material/Pagination";
 import Loading from "elements/Loading";
@@ -13,12 +19,11 @@ import { Title, TitleSpan } from "../UsedBookLikeList/styles";
 const ShopBookReview = () => {
   const { empty, contents, page, pageCount, size, status } = useTypedSelector(userReviewsSelector);
   const loading = status === "loading";
-  const shop = useTypedSelector(userSelector);
+  const { shop } = useTypedSelector(userReduceSelector);
   const dispatch = useAppDispatch();
 
-  const makeQuery = (userId: number, page: number, size: number) => {
+  const makeQuery = (page: number, size: number) => {
     return queryString.stringify({
-      userId,
       page,
       size,
     });
@@ -30,17 +35,22 @@ const ShopBookReview = () => {
       if (contents && contents[currentPage]) {
         dispatch(setReviewPage(currentPage));
       } else {
-        const query = makeQuery(shop.id, currentPage, size);
-        dispatch(fetchReviewAsync(query));
+        const query = makeQuery(currentPage, size);
+        dispatch(fetchReviewAsync({ userId: shop.id, query }));
       }
     }
   };
 
   useEffect(() => {
-    if (shop === null || page !== 0 || contents !== null) return;
-    const query = makeQuery(shop.id, page, size);
-    dispatch(fetchReviewAsync(query));
+    if (shop !== null && page === 0 && contents === null) {
+      const query = makeQuery(page, size);
+      dispatch(fetchReviewAsync({ userId: shop.id, query }));
+    }
   }, [dispatch, shop, page, size, contents]);
+
+  useEffect(() => {
+    dispatch(setReivewsReset());
+  }, []);
 
   if (contents) {
     return (

--- a/src/components/ShopMenu/ShopSaleList.tsx
+++ b/src/components/ShopMenu/ShopSaleList.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useState } from "react";
+import { userReduceSelector } from "src/modules/Slices/user/userSlice";
+import { useTypedSelector } from "src/modules/store";
+import queryString from "query-string";
+import client, { makeAuthTokenHeader } from "src/api/client";
+import noComments from "assets/image/noComments.png";
+import { getShopPage, removeShopPage, setShopPage } from "src/utils/localStorageUtil";
+import { Link } from "react-router-dom";
+import { compareDateFormat, make1000UnitsCommaFormet } from "src/utils/formatUtil";
+import { Box, Skeleton } from "@mui/material";
+import { SaleListResponse, SaleListState, StateEnumType } from "../SaleList/types";
+import { EmptyWrapper, Title, TitleSpan, UsedBookLikeImg, UsedBookLikeListWrapper } from "../UsedBookLikeList/styles";
+import { CountWrapper } from "../UsedBookDetail/style";
+import { ReviewListEmptyParagraph } from "../Reviews/ReviewList/style";
+import { UsedBookCardWrapper } from "../UsedBookList/style";
+import { DateWrapper, ShopContentWrapper, ShopReviewListEmptyWrapper } from "./styles";
+import { FlexBox } from "../BuyList/styles";
+
+const ShopSaleList = () => {
+  const { user, token, shop } = useTypedSelector(userReduceSelector);
+  const [list, setList] = useState<SaleListState>({
+    page: getShopPage(1),
+    pageCount: 0,
+    pages: [],
+    isEmpty: false,
+  });
+  const [limit] = useState(10);
+  const { pages, page } = list;
+
+  const handleHasMoreList = useCallback(
+    async (page: number, limit: number) => {
+      if (!user || !token || !shop) throw new Error("로그인이 필요합니다.");
+      const query = queryString.stringify({ userId: shop.id, page, limit });
+      const { data } = await client.get<SaleListResponse>(`/usedbook/user?${query}`, makeAuthTokenHeader(token));
+      const { pageCount, pages } = data;
+      setList({
+        pageCount,
+        pages,
+        page,
+        isEmpty: pages.length === 0 ? true : false,
+      });
+    },
+    [user, token, shop],
+  );
+
+  const handlePaginationOnChange = useCallback(
+    (_: React.ChangeEvent<unknown>, value: number) => handleHasMoreList(value, limit),
+    [handleHasMoreList, limit],
+  );
+
+  useEffect(() => {
+    const { pages, pageCount, isEmpty, page } = list;
+    if (pages.length === 0 && pageCount === 0 && !isEmpty) handleHasMoreList(page, limit);
+  }, [handleHasMoreList, list, limit]);
+
+  useEffect(() => {
+    if (getShopPage() === 0) setShopPage(page);
+    return () => {
+      removeShopPage();
+    };
+  });
+
+  const STATE_ENUM: StateEnumType = {
+    SALE: "판매 중",
+    SOLD_OUT: "판매완료",
+    TRADING: "거래 중",
+  };
+
+  return (
+    <ShopContentWrapper>
+      <Title>
+        <TitleSpan>판매상품</TitleSpan>
+        <CountWrapper>{pages.length}</CountWrapper>
+      </Title>
+      {pages.length !== 0 ? (
+        <UsedBookLikeListWrapper>
+          {pages.map((card, idx) => {
+            const { id, image, price, state, title, uploadDate } = card;
+            const date = compareDateFormat(String(uploadDate));
+            let dayAgo = "일전";
+            if (date === 0) {
+              dayAgo = "오늘";
+            }
+            return (
+              <div key={idx}>
+                <UsedBookCardWrapper width={100}>
+                  <Link to={`/usedBook/${id}`}>
+                    <div className="usedBookCard__imgBox">
+                      <img src={`${process.env.BASE_URL}/image/${image}`} alt="usedBookImg" />
+                    </div>
+                    <div className="usedBookCard__content">
+                      <p className="usedBookCard__title">{title}</p>
+                      <div className="usedBookCard__price">
+                        <strong>판매가</strong>
+                        <span>:</span>
+                        <span> {make1000UnitsCommaFormet(`${price}`)}원</span>
+                      </div>
+                      <DateWrapper>
+                        {date !== 0 ? (
+                          <>
+                            {date} {dayAgo}
+                          </>
+                        ) : (
+                          // eslint-disable-next-line react/jsx-no-useless-fragment
+                          <>{dayAgo}</>
+                        )}
+                      </DateWrapper>
+                      <p className={`${state === "SOLD_OUT" ? "red" : ""} usedBookCard__state`}>{STATE_ENUM[state]}</p>
+                    </div>
+                  </Link>
+                </UsedBookCardWrapper>
+              </div>
+            );
+          })}
+        </UsedBookLikeListWrapper>
+      ) : list.isEmpty ? (
+        <ShopReviewListEmptyWrapper>
+          <EmptyWrapper>
+            <UsedBookLikeImg src={noComments} alt="noComments" />
+            <ReviewListEmptyParagraph>판매상품이 존재하지 않습니다.</ReviewListEmptyParagraph>
+          </EmptyWrapper>
+        </ShopReviewListEmptyWrapper>
+      ) : (
+        Array.from({ length: 3 }).map((_, idx) => (
+          <FlexBox key={idx}>
+            {Array.from({ length: 5 }).map((_, idx) => (
+              <div key={idx}>
+                <Box sx={{ width: 210, marginRight: 3, my: 5 }}>
+                  <Skeleton variant="rectangular" width={160} height={118} />
+                  <Box sx={{ pt: 0.5 }}>
+                    <Skeleton width="75%" />
+                    <Skeleton width="60%" />
+                  </Box>
+                </Box>
+              </div>
+            ))}
+          </FlexBox>
+        ))
+      )}
+    </ShopContentWrapper>
+  );
+};
+
+export default ShopSaleList;

--- a/src/components/ShopMenu/ShopSaleList.tsx
+++ b/src/components/ShopMenu/ShopSaleList.tsx
@@ -97,12 +97,11 @@ const ShopSaleList = () => {
                       </div>
                       <DateWrapper>
                         {date !== 0 ? (
-                          <>
+                          <span>
                             {date} {dayAgo}
-                          </>
+                          </span>
                         ) : (
-                          // eslint-disable-next-line react/jsx-no-useless-fragment
-                          <>{dayAgo}</>
+                          <span>{dayAgo}</span>
                         )}
                       </DateWrapper>
                       <p className={`${state === "SOLD_OUT" ? "red" : ""} usedBookCard__state`}>{STATE_ENUM[state]}</p>

--- a/src/components/ShopMenu/ShopUserReview.tsx
+++ b/src/components/ShopMenu/ShopUserReview.tsx
@@ -96,7 +96,7 @@ const ShopUserReview = () => {
       </ShopTitle>
       {headerList}
       <div>{receivedMyReviewList}</div>
-      {storeReviewList.length ? (
+      {storeReviewList.length !== 0 && (
         <Stack mt={5} justifyContent="center" direction="row">
           <Pagination
             count={pageCount}
@@ -113,9 +113,6 @@ const ShopUserReview = () => {
             }}
           />
         </Stack>
-      ) : (
-        // eslint-disable-next-line react/jsx-no-useless-fragment
-        <></>
       )}
     </ShopContentWrapper>
   );

--- a/src/components/ShopMenu/ShopUserReview.tsx
+++ b/src/components/ShopMenu/ShopUserReview.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from "react";
+import useSignIn from "src/hooks/useSignIn";
+import noComments from "assets/image/noComments.png";
+import { getShopPage, removeShopPage, setShopPage } from "src/utils/localStorageUtil";
+import { useTypedSelector } from "src/modules/store";
+import Stack from "@mui/material/Stack";
+import Pagination from "@mui/material/Pagination";
+import {
+  getStoreUserReviewList,
+  setReviewInit,
+  usedBookDetailSelector,
+} from "src/modules/Slices/usedBookDetail/usedBookDetailSlice";
+import { userReduceSelector } from "src/modules/Slices/user/userSlice";
+import ReceivedReviewContent from "../UserReview/ReceivedReviewContent";
+import { Empty } from "../SaleList/style";
+import { ReviewListEmptyParagraph, ReviewListEmptyWrapper } from "../Reviews/ReviewList/style";
+import {
+  ShopContentWrapper,
+  ShopSaleCell,
+  ShopSaleTableHeader,
+  ShopTitle,
+  StoreReviewListCount,
+  UserReviewTitleSpan,
+} from "./styles";
+
+const ShopUserReview = () => {
+  const { dispatch } = useSignIn();
+  const headers = ["별점", "구매자명", "상품명", "내용", "작성일"];
+  const { storeReviewList, pageCount } = useTypedSelector(usedBookDetailSelector);
+  const { shop } = useTypedSelector(userReduceSelector);
+  const [page, setPage] = useState(getShopPage(1));
+  const sellerId = shop?.id;
+
+  const handleHasMoreList = useCallback(
+    async (page: number) => {
+      if (sellerId !== undefined) {
+        dispatch(getStoreUserReviewList({ sellerId, page }));
+      }
+    },
+    [dispatch, sellerId],
+  );
+
+  useEffect(() => {
+    setReviewInit();
+    if (pageCount !== 0 && storeReviewList.length !== 0) {
+      handleHasMoreList(1);
+    }
+  }, [sellerId]);
+
+  useEffect(() => {
+    if (storeReviewList.length === 0 && pageCount === 0) handleHasMoreList(page);
+  }, [handleHasMoreList, page]);
+
+  const handlePaginationOnChange = useCallback(
+    (_: React.ChangeEvent<unknown>, value: number) => {
+      handleHasMoreList(value);
+      setPage(value);
+    },
+    [handleHasMoreList],
+  );
+
+  useEffect(() => {
+    if (getShopPage() === 0) setShopPage(page);
+    return () => {
+      removeShopPage();
+    };
+  });
+
+  const headerList = (
+    <ShopSaleTableHeader>
+      {headers.map((text, idx) => (
+        <ShopSaleCell key={idx}>
+          <span>{text}</span>
+        </ShopSaleCell>
+      ))}
+    </ShopSaleTableHeader>
+  );
+
+  const receivedMyReviewList = storeReviewList.length ? (
+    <ReceivedReviewContent contents={storeReviewList} />
+  ) : (
+    <Empty>
+      <ReviewListEmptyWrapper>
+        <ReviewListEmptyParagraph>받은 거래후기가 존재하지 않습니다.</ReviewListEmptyParagraph>
+        <img src={noComments} alt="noComments" />
+      </ReviewListEmptyWrapper>
+    </Empty>
+  );
+
+  return (
+    <ShopContentWrapper>
+      <ShopTitle>
+        <UserReviewTitleSpan>
+          받은 거래 후기 <StoreReviewListCount>{storeReviewList.length * 2}</StoreReviewListCount>
+        </UserReviewTitleSpan>
+      </ShopTitle>
+      {headerList}
+      <div>{receivedMyReviewList}</div>
+      {storeReviewList.length ? (
+        <Stack mt={5} justifyContent="center" direction="row">
+          <Pagination
+            count={pageCount}
+            page={page}
+            onChange={handlePaginationOnChange}
+            variant="outlined"
+            shape="rounded"
+            size="large"
+            sx={{
+              ".Mui-selected": {
+                background: theme => theme.colors.mainDarkBrown,
+                color: theme => theme.colors.white,
+              },
+            }}
+          />
+        </Stack>
+      ) : (
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        <></>
+      )}
+    </ShopContentWrapper>
+  );
+};
+
+export default ShopUserReview;

--- a/src/components/ShopMenu/styles.ts
+++ b/src/components/ShopMenu/styles.ts
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+
+export const ShopUserReviewWrapper = styled.div`
+  margin-top: 50px;
+`;
+
+export const ShopContentWrapper = styled.div`
+  margin: 2rem 0;
+  padding: 0 1rem;
+  flex: 1;
+`;
+
+export const ShopUserReviewHeaderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+`;
+
+export const UserReviewTitleSpan = styled.span`
+  margin: 0 130px 20px 20px;
+`;
+
+export const ShopReviewListEmptyWrapper = styled.div`
+  width: 100%;
+  margin: 0 0 20px;
+  padding: 16px;
+  background-color: #fff;
+  border-radius: 10px;
+`;
+
+export const DateWrapper = styled.div`
+  text-align: center;
+`;
+
+export const ShopTitle = styled.div`
+  width: 100%;
+  height: 30px;
+  font-size: 24px;
+  font-weight: 800;
+  line-height: 1.67;
+  letter-spacing: -0.45px;
+  text-align: left;
+  color: #4f3629;
+  margin-bottom: 20px;
+`;
+
+export const ShopSaleTableHeader = styled.div`
+  display: flex;
+  & > div {
+    text-align: center;
+    flex: 1;
+    border-top: 1px solid rgba(99, 110, 114, 0.2);
+    border-bottom: 1px solid rgba(99, 110, 114, 0.2);
+    padding: 0 0.5rem;
+    & > span {
+      display: block;
+      margin: 15px 0;
+      font-size: 1rem;
+      font-weight: 500;
+      color: ${({ theme }) => theme.colors.darkGrey};
+    }
+  }
+`;
+export const ShopSaleCell = styled.div`
+  flex: 1;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 0.5rem;
+  a {
+    flex: 1;
+  }
+`;
+
+export const StoreReviewListCount = styled.span`
+  color: #dd002c;
+`;

--- a/src/components/ShopTop/ShopTop.tsx
+++ b/src/components/ShopTop/ShopTop.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from "react";
+import noProfileImg from "assets/image/noProfile.jpg";
+import { dateArrayFormat } from "src/utils/formatUtil";
+import { UserInfo } from "src/modules/Slices/user/types";
+import Rating from "@mui/material/Rating";
+import { GetChartResponse } from "src/modules/Slices/userReview/types";
+import MyChart from "../MyTop/MyChart";
+import { MyChartWrapper, ProfileImg, EmptyChart, TitleSpan } from "../MyTop/style";
+import { ShopTopUserInfo, ShopTopWrapper } from "./styles";
+import { RatingContent } from "../BookDetail/style";
+
+export interface ShopTopParam {
+  shop: UserInfo;
+  chart: GetChartResponse[];
+}
+
+const ShopTop = ({ shop, chart }: ShopTopParam) => {
+  const getRating = useCallback((point: number) => {
+    let rating = "브론즈";
+    if (point >= 100000) {
+      rating = "실버";
+    }
+    if (point >= 1000000) {
+      rating = "골드";
+    }
+    return rating;
+  }, []);
+
+  return (
+    <ShopTopWrapper>
+      {shop && (
+        <>
+          <ProfileImg>
+            <img src={shop.image ? `${process.env.BASE_URL}/image/${shop.image}` : noProfileImg} alt="myProfileImg" />
+          </ProfileImg>
+          <ShopTopUserInfo>
+            <span>{`${getRating(shop.point.totalPoint)}회원`}</span>
+            <div>
+              <span>{shop.nickName}</span>
+            </div>
+            <div>
+              <span>회원가입일</span> <span>{dateArrayFormat(shop.createDate)[0]}</span>
+            </div>
+            <RatingContent>
+              <Rating name="read-only" precision={0.5} value={shop.rating} size="small" readOnly />
+            </RatingContent>
+          </ShopTopUserInfo>
+          <MyChartWrapper>
+            <TitleSpan>선호 장르</TitleSpan>
+            {chart.length !== 0 ? (
+              <MyChart data={chart} />
+            ) : (
+              <EmptyChart>
+                <div>
+                  <p>선호장르 데이터가 없습니다.</p>
+                </div>
+              </EmptyChart>
+            )}
+          </MyChartWrapper>
+        </>
+      )}
+    </ShopTopWrapper>
+  );
+};
+
+export default ShopTop;

--- a/src/components/ShopTop/styles.ts
+++ b/src/components/ShopTop/styles.ts
@@ -1,0 +1,115 @@
+import styled from "styled-components";
+
+export const ShopTopWrapper = styled.section`
+  display: flex;
+  gap: 1rem;
+  margin: 0 1rem;
+
+  & > div:first-child {
+    flex: 7;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  & > div:last-child {
+    flex: 7;
+  }
+
+  @media screen and (max-width: 900px) {
+    flex-direction: column;
+  }
+
+  ${({ theme }) => theme.media.mobile} {
+    margin: 0;
+    padding: 0 0.5rem;
+    & > div:first-child {
+      flex-direction: column;
+    }
+  } ;
+`;
+
+export const ShopTopUserInfo = styled.div`
+  flex: 6;
+  padding: 1rem;
+  padding-top: 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: ${({ theme }) => theme.colors.mainDarkBrown};
+
+  a {
+    display: block;
+    flex: 1;
+  }
+
+  & > form,
+  & > div {
+    display: flex;
+    height: 40px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    & > span:first-child {
+      font-size: 1.2rem;
+      color: ${({ theme }) => theme.colors.darkGrey};
+      font-weight: 500;
+    }
+    & > span:nth-child(2) {
+      color: ${({ theme }) => theme.colors.info};
+      font-size: 1rem;
+    }
+  }
+
+  button:first-child {
+    width: 100%;
+  }
+
+  button:nth-child(2) {
+    width: 110px;
+    transition: opacity 0.25s ease-in;
+    :hover {
+      opacity: 0.8;
+    }
+  }
+  .errorMessage {
+    padding: 0.2rem 1rem;
+    & > span:first-child {
+      font-size: 0.9rem;
+      color: ${({ theme }) => theme.colors.white};
+    }
+  }
+  .skeleton {
+    height: auto;
+  }
+
+  @media screen and (max-width: 900px) {
+    padding: 1rem;
+  }
+
+  ${({ theme }) => theme.media.mobile} {
+    padding: 1.1rem 0.7rem;
+    width: 100%;
+    & > form,
+    & > div {
+      span:first-child {
+        font-size: 0.8rem;
+      }
+      span:nth-child(2) {
+        font-size: 0.7rem;
+      }
+    }
+    button {
+      font-size: 0.6rem;
+    }
+
+    .errorMessage {
+      padding: 0.5rem;
+      height: 50px;
+      & > span:first-child {
+        font-size: 0.8rem;
+        color: ${({ theme }) => theme.colors.white};
+      }
+    }
+  } ;
+`;

--- a/src/components/UsedBookDetail/RelatedUsedBook/RelatedUsedBook.tsx
+++ b/src/components/UsedBookDetail/RelatedUsedBook/RelatedUsedBook.tsx
@@ -74,12 +74,11 @@ const RelatedUsedBook = () => {
             <RelatedUsedBookBoldTitle brown>{make1000UnitsCommaFormet(String(price))}원</RelatedUsedBookBoldTitle>
             <RelatedUsedBookHashTagItem>
               {date !== 0 ? (
-                <>
+                <span>
                   {date} {dayAgo}
-                </>
+                </span>
               ) : (
-                // eslint-disable-next-line react/jsx-no-useless-fragment
-                <>{dayAgo}</>
+                <span>{dayAgo}</span>
               )}
             </RelatedUsedBookHashTagItem>
           </RelatedUsedBookItemContentWrapper>

--- a/src/components/UsedBookDetail/UsedBookInquiry/UsedBookReplyItem.tsx
+++ b/src/components/UsedBookDetail/UsedBookInquiry/UsedBookReplyItem.tsx
@@ -11,6 +11,7 @@ import Textarea from "src/components/TextArea/Textarea";
 import { useTypedSelector } from "src/modules/store";
 import { userReduceSelector } from "src/modules/Slices/user/userSlice";
 import { useHistory } from "react-router";
+import { Link } from "react-router-dom";
 import { DateContent, SecretItem } from "./styles";
 import {
   ContentWrapper,
@@ -44,6 +45,7 @@ export const UsedBookReplyItem = ({ review, sellerId, sellerName, page }: UsedBo
   const [isSubReplyAdd, setIsSubReplyAdd] = useState<boolean>(false);
   const { id } = user ?? noId;
   const date = compareDateFormat(replyDate);
+  const shopId = String(userId);
   let dayAgo = "일전";
   if (date === 0) {
     dayAgo = "오늘";
@@ -99,9 +101,11 @@ export const UsedBookReplyItem = ({ review, sellerId, sellerName, page }: UsedBo
       <ReplyItemWrapper>
         <FlexBoxWrapper>
           <FlexBox>
-            <ProfileArea>
-              <PieImg src={profileImg} alt="profileImg" />
-            </ProfileArea>
+            <Link to={`/shop/${shopId}`}>
+              <ProfileArea>
+                <PieImg src={profileImg} alt="profileImg" />
+              </ProfileArea>
+            </Link>
             <ContentWrapper>
               <ClickArea>
                 {id === sellerId && (

--- a/src/components/UsedBookDetail/UsedBookStoreInformation/ProductDetailCard.tsx
+++ b/src/components/UsedBookDetail/UsedBookStoreInformation/ProductDetailCard.tsx
@@ -6,14 +6,14 @@ import {
   ProductDetailCardWrapper,
   UsedStoreUserThumbnail,
   UsedBookDetailButton,
-  BigPieImg,
   ProductDetailCardFlexWrapper,
 } from "../style";
+import { UsedBookStoreProfileImg } from "./styles";
 import UsedStoreUserContent from "./UsedStoreUserContent";
 
 const ProductDetailCard = () => {
   const { content } = useTypedSelector(usedBookDetailSelector);
-  const { sellerName } = content;
+  const { sellerName, sellerImage } = content;
   const { sellerId } = content;
   const shopId = String(sellerId);
 
@@ -22,7 +22,9 @@ const ProductDetailCard = () => {
       <ProductDetailCardFlexWrapper>
         <UsedStoreUserThumbnail>
           <Link to={`/shop/${shopId}`}>
-            <BigPieImg src={profileImg} alt="profileImg" />
+            <UsedBookStoreProfileImg>
+              <img src={sellerImage ? `${process.env.BASE_URL}/image/${sellerImage}` : profileImg} alt="myProfileImg" />
+            </UsedBookStoreProfileImg>
           </Link>
         </UsedStoreUserThumbnail>
         <UsedStoreUserContent sellerName={sellerName} />

--- a/src/components/UsedBookDetail/UsedBookStoreInformation/ProductDetailCard.tsx
+++ b/src/components/UsedBookDetail/UsedBookStoreInformation/ProductDetailCard.tsx
@@ -1,6 +1,7 @@
 import profileImg from "assets/image/pie3x.png";
 import { usedBookDetailSelector } from "modules/Slices/usedBookDetail/usedBookDetailSlice";
 import { useTypedSelector } from "modules/store";
+import { Link } from "react-router-dom";
 import {
   ProductDetailCardWrapper,
   UsedStoreUserThumbnail,
@@ -13,12 +14,16 @@ import UsedStoreUserContent from "./UsedStoreUserContent";
 const ProductDetailCard = () => {
   const { content } = useTypedSelector(usedBookDetailSelector);
   const { sellerName } = content;
+  const { sellerId } = content;
+  const shopId = String(sellerId);
 
   return (
     <ProductDetailCardWrapper>
       <ProductDetailCardFlexWrapper>
         <UsedStoreUserThumbnail>
-          <BigPieImg src={profileImg} alt="profileImg" />
+          <Link to={`/shop/${shopId}`}>
+            <BigPieImg src={profileImg} alt="profileImg" />
+          </Link>
         </UsedStoreUserThumbnail>
         <UsedStoreUserContent sellerName={sellerName} />
       </ProductDetailCardFlexWrapper>

--- a/src/components/UsedBookDetail/UsedBookStoreInformation/UsedBookStoreReview.tsx
+++ b/src/components/UsedBookDetail/UsedBookStoreInformation/UsedBookStoreReview.tsx
@@ -17,12 +17,12 @@ import {
   StoreReviewItemContent,
   StoreReviewItemNickName,
   StoreReviewItemWrapper,
+  StoreReviewProfileImg,
 } from "./styles";
 import {
   ContentWrapper,
   CountWrapper,
   FlexBoxWrapper,
-  PieImg,
   ProductDetailTitle,
   ProfileArea,
   ReviewListEmptyWrapper,
@@ -72,14 +72,16 @@ const UsedBookStoreReview = () => {
   });
 
   const reviewList = storeReviewList.map((item, idx) => {
-    const { buyerName, content, rating, reviewDate, buyerId } = item;
+    const { buyerName, content, rating, reviewDate, buyerId, buyerImage } = item;
     const shopId = String(buyerId);
     return (
       <StoreReviewItemWrapper key={idx}>
         <FlexBoxWrapper>
           <Link to={`/shop/${shopId}`}>
             <ProfileArea>
-              <PieImg src={profileImg} alt="profileImg" />
+              <StoreReviewProfileImg>
+                <img src={buyerImage ? `${process.env.BASE_URL}/image/${buyerImage}` : profileImg} alt="myProfileImg" />
+              </StoreReviewProfileImg>
             </ProfileArea>
           </Link>
           <ContentWrapper>

--- a/src/components/UsedBookDetail/UsedBookStoreInformation/UsedBookStoreReview.tsx
+++ b/src/components/UsedBookDetail/UsedBookStoreInformation/UsedBookStoreReview.tsx
@@ -113,7 +113,7 @@ const UsedBookStoreReview = () => {
           <ReviewListEmpty title="상점후기" />
         </ReviewListEmptyWrapper>
       )}
-      {reviewList.length ? (
+      {reviewList.length !== 0 && (
         <Stack mt={5} justifyContent="center" direction="row">
           <Pagination
             count={pageCount}
@@ -130,9 +130,6 @@ const UsedBookStoreReview = () => {
             }}
           />
         </Stack>
-      ) : (
-        // eslint-disable-next-line react/jsx-no-useless-fragment
-        <></>
       )}
     </UsedBookStoreInformationWrapper>
   );

--- a/src/components/UsedBookDetail/UsedBookStoreInformation/UsedBookStoreReview.tsx
+++ b/src/components/UsedBookDetail/UsedBookStoreInformation/UsedBookStoreReview.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { ReviewListEmpty } from "components/Reviews/ReviewList/ReviewListEmpty";
 import { useRouteMatch } from "react-router";
+import { Link } from "react-router-dom";
 import {
   FlexBox,
   RatingContent,
@@ -71,13 +72,16 @@ const UsedBookStoreReview = () => {
   });
 
   const reviewList = storeReviewList.map((item, idx) => {
-    const { buyerName, content, rating, reviewDate } = item;
+    const { buyerName, content, rating, reviewDate, buyerId } = item;
+    const shopId = String(buyerId);
     return (
       <StoreReviewItemWrapper key={idx}>
         <FlexBoxWrapper>
-          <ProfileArea>
-            <PieImg src={profileImg} alt="profileImg" />
-          </ProfileArea>
+          <Link to={`/shop/${shopId}`}>
+            <ProfileArea>
+              <PieImg src={profileImg} alt="profileImg" />
+            </ProfileArea>
+          </Link>
           <ContentWrapper>
             <RatingContent>
               <Rating name="read-only" precision={0.5} value={rating} size="small" readOnly />

--- a/src/components/UsedBookDetail/UsedBookStoreInformation/styles.ts
+++ b/src/components/UsedBookDetail/UsedBookStoreInformation/styles.ts
@@ -53,3 +53,29 @@ export const StoreReviewItemNickName = styled.div`
   text-align: left;
   color: #fff;
 `;
+
+export const UsedBookStoreProfileImg = styled.div`
+  flex: 6;
+  display: flex;
+  align-items: center;
+
+  img {
+    width: 120px;
+    height: 80px;
+    margin-bottom: 8px;
+    border-radius: 80%;
+  }
+`;
+
+export const StoreReviewProfileImg = styled.div`
+  flex: 6;
+  display: flex;
+  align-items: center;
+
+  img {
+    width: 50px;
+    height: 50px;
+    margin-bottom: 8px;
+    border-radius: 80%;
+  }
+`;

--- a/src/components/UsedBookLikeList/styles.ts
+++ b/src/components/UsedBookLikeList/styles.ts
@@ -14,7 +14,7 @@ export const UsedBookLikeImg = styled.img`
 
 export const UsedBookLikeListWrapper = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: 20px;
   margin-top: 2rem;
   margin-bottom: 150px;

--- a/src/components/UserReview/UserReview.tsx
+++ b/src/components/UserReview/UserReview.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
 import useSignIn from "hooks/useSignIn";
 import noComments from "assets/image/noComments.png";
 import queryString from "query-string";
@@ -12,16 +11,16 @@ import {
   getUserReviewList,
   userReviewSelector,
 } from "modules/Slices/userReview/userReviewSlice";
-import { CancelButton, FlexBox, HeaderTitle, UserReviewButtonArea, UserReviewHeaderWrapper } from "../BuyList/styles";
+import { CancelButton, FlexBox, UserReviewButtonArea } from "../BuyList/styles";
 import { ReviewListEmptyParagraph, ReviewListEmptyWrapper } from "../Reviews/ReviewList/style";
 import { Empty } from "../SaleList/style";
 import WrittedReviewList from "./WrittedReviewList";
 import ReceivedReviewContent from "./ReceivedReviewContent";
 import MyPageSkeleton from "../BuyList/MyPageSkeleton";
+import { UserReviewCell, UserReviewHeader, UserReviewWrapper } from "./styles";
 
 const UserReview = () => {
-  const dispatch = useDispatch();
-  const { signIn } = useSignIn();
+  const { signIn, dispatch } = useSignIn();
   const { user } = signIn;
   const [receivedReview, writtedReview] = useState(true);
   const receivedReviewHeader = ["별점", "구매자명", "상품명", "내용", "작성일"];
@@ -83,11 +82,15 @@ const UserReview = () => {
     };
   });
 
-  const headerList = headers.map((header, idx) => (
-    <div key={idx}>
-      <HeaderTitle>{header}</HeaderTitle>
-    </div>
-  ));
+  const headerList = (
+    <UserReviewHeader>
+      {headers.map((text, idx) => (
+        <UserReviewCell key={idx}>
+          <span>{text}</span>
+        </UserReviewCell>
+      ))}
+    </UserReviewHeader>
+  );
 
   const writtedReviewList = pages.length ? (
     <WrittedReviewList contents={pages} dispatch={dispatch} signIn={signIn} />
@@ -124,12 +127,12 @@ const UserReview = () => {
   );
 
   return (
-    <div>
+    <UserReviewWrapper>
       <UserReviewButtonArea>
         <CancelButton onClick={receivedReviewClick}>받은 거래 후기</CancelButton>
         <CancelButton onClick={writtedReviewClick}>작성 거래 후기</CancelButton>
       </UserReviewButtonArea>
-      <UserReviewHeaderWrapper>{headerList}</UserReviewHeaderWrapper>
+      {headerList}
       {receivedReview ? <div>{receivedMyReviewList}</div> : <div>{writtedReviewList}</div>}
       {list.isEmpty || (
         <Stack mt={5} justifyContent="center" direction="row">
@@ -149,7 +152,7 @@ const UserReview = () => {
           />
         </Stack>
       )}
-    </div>
+    </UserReviewWrapper>
   );
 };
 

--- a/src/components/UserReview/styles.ts
+++ b/src/components/UserReview/styles.ts
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+export const UserReviewHeader = styled.div`
+  display: flex;
+  & > div {
+    text-align: center;
+    flex: 1;
+    border-top: 1px solid rgba(99, 110, 114, 0.2);
+    border-bottom: 1px solid rgba(99, 110, 114, 0.2);
+    padding: 0 0.5rem;
+    & > span {
+      display: block;
+      margin: 15px 0;
+      font-size: 1rem;
+      font-weight: 500;
+      color: ${({ theme }) => theme.colors.darkGrey};
+    }
+  }
+`;
+export const UserReviewCell = styled.div`
+  flex: 1;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 0.5rem;
+  a {
+    flex: 1;
+  }
+`;
+
+export const UserReviewWrapper = styled.div`
+  margin: 1rem 0;
+  padding: 0 1rem;
+  flex: 1;
+`;

--- a/src/modules/Slices/usedBookDetail/types.ts
+++ b/src/modules/Slices/usedBookDetail/types.ts
@@ -128,6 +128,7 @@ export interface UsedBookDetailResponse {
   usedBookId: number;
   sellerId: number;
   sellerName: string;
+  sellerImage: string;
   price: number;
   title: string;
   content: string;

--- a/src/modules/Slices/usedBookDetail/types.ts
+++ b/src/modules/Slices/usedBookDetail/types.ts
@@ -205,7 +205,7 @@ export interface UsedBookDetailReduce {
 
 // =========================== 썽크함수 성공 시 리턴 타입 ===========================
 
-export interface getUsedBookLikeListAsyncSuccess {
+export interface GetUsedBookLikeListAsyncSuccess {
   success: boolean;
   data: PagesResponse[];
   error: null;
@@ -247,7 +247,7 @@ export interface usedBookDetailReplyListAsyncSuccess {
   error: null;
 }
 
-export interface getUsedBookBuyListAsyncSuccess {
+export interface GetUsedBookBuyListAsyncSuccess {
   success: boolean;
   data: {
     pageCount: number;

--- a/src/modules/Slices/usedBookDetail/usedBookDetailSlice.ts
+++ b/src/modules/Slices/usedBookDetail/usedBookDetailSlice.ts
@@ -21,8 +21,8 @@ import {
   DeleteUsedBookDetailSubReply,
   editUsedBookDetailReplyParam,
   GetUsedBookBuyConfirmParam,
-  getUsedBookBuyListAsyncSuccess,
-  getUsedBookLikeListAsyncSuccess,
+  GetUsedBookBuyListAsyncSuccess,
+  GetUsedBookLikeListAsyncSuccess,
   UsedBookDetailAsyncSuccess,
   UsedBookDetailFail,
   UsedBookDetailReduce,
@@ -241,7 +241,7 @@ export const deleteUsedBookDetailSubReply = createAsyncThunk<string, DeleteUsedB
 );
 
 // 마이페이지 - 중고장터 찜 목록
-export const getUsedBookLikeList = createAsyncThunk<getUsedBookLikeListAsyncSuccess, string>(
+export const getUsedBookLikeList = createAsyncThunk<GetUsedBookLikeListAsyncSuccess, string>(
   `${myPage}/${name}/like/list`,
   async (token, { rejectWithValue }) => {
     try {
@@ -257,7 +257,7 @@ export const getUsedBookLikeList = createAsyncThunk<getUsedBookLikeListAsyncSucc
 );
 
 // 마이페이지 - 중고장터 구매 목록
-export const getUsedBookBuyList = createAsyncThunk<getUsedBookBuyListAsyncSuccess, getUserReviewListParam>(
+export const getUsedBookBuyList = createAsyncThunk<GetUsedBookBuyListAsyncSuccess, getUserReviewListParam>(
   `${myPage}/${name}/buy/list`,
   async ({ query, token }, { rejectWithValue }) => {
     try {

--- a/src/modules/Slices/user/types.ts
+++ b/src/modules/Slices/user/types.ts
@@ -108,4 +108,5 @@ export interface UserReduce {
     status: "loading" | "idle";
     error: string | null;
   };
+  shop: UserInfo | null;
 }

--- a/src/modules/Slices/user/userSlice.ts
+++ b/src/modules/Slices/user/userSlice.ts
@@ -41,6 +41,24 @@ export const fetchUserInfoAsync = createAsyncThunk<Types.UserInfo, string, Types
 );
 
 /**
+ *   다른 회원 정보 가져오기
+ *   @param  userId
+ *   @return 유저 정보
+ */
+export const fetchShopUserInfoAsync = createAsyncThunk<Types.UserInfo, string>(
+  `${NAME}/fetchShopUserInfoAsync`,
+  async (shopId, { rejectWithValue }) => {
+    try {
+      const { data } = await client.get<Types.UserInfoAsyncResponse>(`/user/${shopId}`);
+      return data;
+    } catch (error) {
+      const message = errorHandler(error);
+      return rejectWithValue(message);
+    }
+  },
+);
+
+/**
  *   1. 썽크 생성 함수의 첫번째 제너릭은 반환 타입을 준다.
  *   2. 썽크 생성 함수의 두번째 제너릭은 파라미터의 타입을 준다.
  *   3. 썽크 생성 함수의 세번째 제너릭은 {dispatch?, state?, extra?, rejectValue?}에 타입을 설정해줄 수 있다.
@@ -163,6 +181,7 @@ const initialState: Types.UserReduce = {
     status: "idle",
     error: null,
   },
+  shop: null,
 };
 
 const userSlice = createSlice({
@@ -218,6 +237,20 @@ const userSlice = createSlice({
       state.status = "idle";
       state.error = payload ?? "프로필 가져오기를 실패했습니다.";
     });
+
+    builder.addCase(fetchShopUserInfoAsync.pending, state => {
+      state.error = null;
+      state.status = "loading";
+    });
+    builder.addCase(fetchShopUserInfoAsync.fulfilled, (state, { payload }) => {
+      state.shop = payload;
+      state.status = "idle";
+    });
+    builder.addCase(fetchShopUserInfoAsync.rejected, (state, { payload }) => {
+      state.token = null;
+      state.status = "idle";
+    });
+
     builder.addCase(fetchBuyInfoAsync.pending, state => {
       state.status = "loading";
     });

--- a/src/modules/Slices/userReview/types.ts
+++ b/src/modules/Slices/userReview/types.ts
@@ -61,6 +61,7 @@ export interface UserReviewData {
   sellerName: string;
   buyerId: number;
   buyerName: string;
+  buyerImage: string;
   usedBookId: number;
   usedBookTitle: string;
   content: string;

--- a/src/modules/Slices/userReview/userReviewSlice.ts
+++ b/src/modules/Slices/userReview/userReviewSlice.ts
@@ -111,11 +111,9 @@ export const deleteUserReview = createAsyncThunk<DeleteUserReviewAsyncSuccess, D
 // 마이페이지 - 차트
 export const getMyPageChart = createAsyncThunk<GetChartAsyncSuccess, string>(
   `${name}/getChart`,
-  async (token, { rejectWithValue }) => {
+  async (id, { rejectWithValue }) => {
     try {
-      const response = await http.get(`/book-review/myCategory`, {
-        headers: { "X-AUTH-TOKEN": token },
-      });
+      const response = await http.get(`/book-review/myCategory/${id}`);
       return response.data;
     } catch (error: any) {
       console.error(error);

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -1,0 +1,101 @@
+import { Tab, Tabs } from "@mui/material";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { useDispatch } from "react-redux";
+import { NavLink, Route, Switch, useParams } from "react-router-dom";
+import ShopTop from "src/components/ShopTop/ShopTop";
+import { fetchShopUserInfoAsync, userReduceSelector } from "src/modules/Slices/user/userSlice";
+import { getMyPageChart, userReviewSelector } from "src/modules/Slices/userReview/userReviewSlice";
+import { useTypedSelector } from "src/modules/store";
+import FallBack from "./FallBack";
+import { MyContainer, MyRouterWrapper, ShopMenuTabWrapper } from "./styles";
+
+export interface ShopParam {
+  shopId: string;
+}
+const ShopSaleList = lazy(() => import("components/ShopMenu/ShopSaleList"));
+const ShopBookReview = lazy(() => import("components/ShopMenu/ShopBookReview"));
+const ShopUserReview = lazy(() => import("components/ShopMenu/ShopUserReview"));
+
+const Shop = () => {
+  const dispatch = useDispatch();
+  const { shopId } = useParams<ShopParam>();
+  const [value, setValue] = useState(2);
+  const { shop } = useTypedSelector(userReduceSelector);
+  const { myPageChart } = useTypedSelector(userReviewSelector);
+  const id = String(shopId);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  const myMenus = useMemo(
+    () =>
+      [
+        {
+          id: 1,
+          text: "판매 상품",
+          fullPath: `/shop/${shopId}/saleList`,
+        },
+        {
+          id: 2,
+          text: "작성도서 리뷰",
+          fullPath: `/shop/${shopId}/bookReview`,
+        },
+        {
+          id: 3,
+          text: "받은 거래 후기",
+          fullPath: `/shop/${shopId}/userReview`,
+        },
+        {
+          id: 4,
+          text: "팔로잉 ",
+          fullPath: `/shop/${shopId}/userReview`,
+        },
+        {
+          id: 5,
+          text: "팔로워 ",
+          fullPath: `/shop/${shopId}/userReview`,
+        },
+      ].map(({ id, text, fullPath }) => (
+        <Tab
+          key={id}
+          value={id}
+          label={
+            <NavLink activeClassName="is-active" to={fullPath}>
+              {text}
+            </NavLink>
+          }
+        />
+      )),
+    [shopId],
+  );
+  const handleChange = (_: any, newValue: number) => setValue(newValue);
+
+  useEffect(() => {
+    dispatch(fetchShopUserInfoAsync(shopId));
+    dispatch(getMyPageChart(String(id)));
+  }, [dispatch, shopId]);
+
+  return (
+    <MyContainer>
+      <ShopTop shop={shop} chart={myPageChart} />
+      <ShopMenuTabWrapper>
+        <Tabs value={value} onChange={handleChange} variant="scrollable" allowScrollButtonsMobile scrollButtons>
+          {myMenus}
+        </Tabs>
+      </ShopMenuTabWrapper>
+      <MyRouterWrapper>
+        <Suspense fallback={<FallBack />}>
+          <Switch>
+            <Route path={`/shop/${shopId}/saleList`} exact component={ShopSaleList} />
+            <Route path={`/shop/${shopId}/bookReview`} exact component={ShopBookReview} />
+            <Route path={`/shop/${shopId}/userReview`} exact component={ShopUserReview} />
+            <Route component={ShopBookReview} />
+          </Switch>
+        </Suspense>
+      </MyRouterWrapper>
+    </MyContainer>
+  );
+};
+
+export default Shop;

--- a/src/pages/styles.ts
+++ b/src/pages/styles.ts
@@ -130,6 +130,69 @@ export const MyMenuTabWrapper = styled.section`
   }
 `;
 
+export const ShopMenuTabWrapper = styled.section`
+  margin-top: 1rem;
+
+  .active {
+    background-color: ${({ theme }) => theme.colors.white};
+    color: ${({ theme }) => theme.colors.darkGrey};
+    border: 1px solid ${activeBorderColor};
+    border-bottom: none;
+    opacity: 1;
+    font-weight: bold;
+  }
+  a {
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    border: 1px solid rgba(189, 195, 199, 0.4);
+    border-bottom: 1px solid ${activeBorderColor};
+    background-color: ${({ theme }) => theme.colors.mainLightBrown};
+    opacity: 0.5;
+    text-align: center;
+
+    @media screen and (max-width: 900px) {
+      height: 50px;
+    }
+    ${({ theme }) => theme.media.mobile} {
+      font-size: 0.6rem;
+    }
+    :hover {
+      opacity: 1;
+      color: ${({ theme }) => theme.colors.mainDarkBrown};
+    }
+  }
+  & .MuiTabs-root {
+    position: relative;
+    overflow: visible;
+    width: 100%;
+  }
+
+  @media screen and (max-width: 900px) {
+    & .MuiTabs-flexContainer {
+      display: flex;
+    }
+  }
+  & .MuiButtonBase-root {
+    padding: 0;
+    flex: 1;
+  }
+  & .MuiTabScrollButton-root {
+    position: absolute;
+    z-index: 5;
+    top: 100%;
+    padding: 10px;
+  }
+  & .MuiTabScrollButton-root:first-child {
+    left: 0;
+  }
+  & .MuiTabScrollButton-root:last-child {
+    right: 0;
+  }
+`;
+
 export const MyRouterWrapper = styled.section`
   min-height: 500px;
   display: flex;

--- a/src/router/Routers.tsx
+++ b/src/router/Routers.tsx
@@ -15,6 +15,7 @@ const Order = lazy(() => import("pages/Order"));
 const Community = lazy(() => import("pages/Community"));
 const Search = lazy(() => import("pages/Search"));
 const Chat = lazy(() => import("pages/Chat"));
+const Shop = lazy(() => import("pages/Shop"));
 
 const Routers = () => {
   return (
@@ -31,6 +32,7 @@ const Routers = () => {
       <Route path="/usedBook" component={UsedBook} />
       <Route path="/search" component={Search} />
       <Route path="/book" component={Book} />
+      <Route path="/shop/:shopId" component={Shop} />
       <Route path="*" component={RootRedirect} />
     </Switch>
   );


### PR DESCRIPTION
1. 다른 회원 마이페이지(Shop) 추가
   - 차트 
   - 판매상품
![스크린샷 2022-02-11 오후 10 00 48](https://user-images.githubusercontent.com/69706762/153596365-96b327af-8fca-40a3-8f7a-d1a726e65570.png)

   - 받은거래 후기
![스크린샷 2022-02-11 오후 10 01 06](https://user-images.githubusercontent.com/69706762/153596406-6fe1c841-2448-4030-91e2-8ccd3c3a7f0e.png)

   - 작성 도서 리뷰
![스크린샷 2022-02-11 오후 10 00 57](https://user-images.githubusercontent.com/69706762/153596441-12e3ab33-396d-4851-88c7-83978661dd74.png)


2. 중고장터 상세페이지 - 상점정보, 상점후기 유저 이미지 추가
![스크린샷 2022-02-11 오후 9 58 05](https://user-images.githubusercontent.com/69706762/153596621-53571c94-5987-437b-9eb4-9c0641c84cc6.png)


3. 마이페이지 빈 차트일때 데이터 없음 표시 추가
![스크린샷 2022-02-11 오후 9 59 03](https://user-images.githubusercontent.com/69706762/153596550-d3889f33-3108-411e-a901-d60ee6b70bb7.png)

4. 기타
    - 리뷰 파라미터 방식 변경
    - 차트 파라미터 방식을 토큰 방식에서 userId로 변경
    - 마이페이지 구매, 거래후기 헤더 및 레이아웃 수정
    - 리뷰 작성 모달창 버튼 레이아웃 수정, 구매확정 취소 시 새로고침 하지 않도록 수정
    - 다른 회원 마이페이지 작성리뷰 버그 수정