### PR TITLE
메인페이지 베스트샐러 컴포넌트 css 변경

### DIFF
--- a/src/components/BestSeller/style.ts
+++ b/src/components/BestSeller/style.ts
@@ -6,9 +6,6 @@ export const BestSellerWrapper = styled.div`
   grid-template-rows: repeat(2, 200px);
   row-gap: 10px;
   column-gap: 10px;
-  & > div {
-    ${props => props.theme.shadow[0]};
-  }
 
   @media screen and (max-width: 800px) {
     grid-template-columns: repeat(4, 4fr);
@@ -72,7 +69,7 @@ export const FirstCardWrapper = styled.div`
     line-height: 1.5;
     overflow: hidden;
     text-overflow: ellipsis;
-    -webkit-line-clamp: 5;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     color: ${props => props.theme.colors.white};
     font-size: 1.5rem;
@@ -166,7 +163,7 @@ export const CardWrapper = styled.div`
     line-height: 1.5;
     overflow: hidden;
     text-overflow: ellipsis;
-    -webkit-line-clamp: 5;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     padding-right: 5px;
     color: ${p => p.theme.colors.darkGrey};

--- a/src/modules/Slices/user/userSlice.ts
+++ b/src/modules/Slices/user/userSlice.ts
@@ -152,9 +152,8 @@ export const fetchBuyInfoAsync = createAsyncThunk<OrderResult, string, Types.Thu
  */
 export const fetchReviewAsync = createAsyncThunk<Types.Review, { userId: number; query: string }, Types.ThunkApi>(
   `${NAME}/fetchReviewAsync`,
-  async ({ query, userId }, { getState, rejectWithValue }) => {
+  async ({ query, userId }, { rejectWithValue }) => {
     try {
-      isLoggedInCheck(getState().userReduce);
       const { data } = await client.get<Types.ReviewAsyncReponse>(`/book-review/myReview/${userId}?${query}`);
       return data;
     } catch (error) {


### PR DESCRIPTION
## 1. 메엔페이지 수정 
  - 베스트샐러 `box-shadow css` 제거
<p align=center>
<img src=https://user-images.githubusercontent.com/26589722/153750727-3b9a2d23-7033-4ab6-8558-a7e8842c2434.png 
width=400
height=250/>
</center>
</p>

## 2. 다른 유저 상세페이지
  - 비로그인 상태일때 작성도서 리뷰 가져올 수 있도록 `fetchReviewAsync` thunk함수 수정
  
<p align=center>
<img src=https://user-images.githubusercontent.com/26589722/153750865-64c9b8ad-209e-4bdc-91c4-e208771a3f1c.gif 
width=400
height=250/>
</p>
